### PR TITLE
feat: switch to cdn

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -81,9 +81,9 @@ exports.createPages = async ({ graphql, actions }) => {
       const rng = Math.floor(Math.random() * element.colorways.length);
       const f = element.colorways.find((x) => x.isCover === true);
       if (f) {
-        element.previewImg = f.img;
+        element.previewImg = `https://cdn.keycap-archivist.com/keycaps/${f.id}.jpg`;
       } else {
-        element.previewImg = element.colorways[rng].img;
+        element.previewImg = `https://cdn.keycap-archivist.com/keycaps/${element.colorways[rng].id}.jpg`;
       }
     });
     const makerLightObj = _.cloneDeep(maker);

--- a/src/layouts/cw.js
+++ b/src/layouts/cw.js
@@ -30,7 +30,7 @@ const Maker = (props) => {
   useEffect(() => {
     setStateWishlist(getWishlist());
   }, []);
-
+  const cwImg = `https://cdn.keycap-archivist.com/keycaps/${colorway.id}.jpg`;
   return (
     <Layout>
       {showSuccessAlert && (
@@ -40,7 +40,7 @@ const Maker = (props) => {
       {showExceedAlert && (
         <Alert color="red" alertMessage="Wishlist or trade list items exceeded" setAlert={setShowExceedAlert} />
       )}
-      <SEO title={seoTitle} img={colorway.img} />
+      <SEO title={seoTitle} img={cwImg} />
       <div className="lg:w-3/5 mx-auto">
         <div className="pt-4">
           <Link to="/" className="text-blue-600">
@@ -214,7 +214,7 @@ const Maker = (props) => {
         <div className="flex bg-white border">
           <div className="flex flex-col p-5 mx-auto">
             <div className="colorway-wrapper">
-              <img loading="lazy" className="block h-full w-full object-cover" alt={seoTitle} src={colorway.img} />
+              <img loading="lazy" className="block h-full w-full object-cover" alt={seoTitle} src={cwImg} />
             </div>
           </div>
         </div>

--- a/src/layouts/sculpt.js
+++ b/src/layouts/sculpt.js
@@ -103,7 +103,7 @@ const Maker = (props) => {
                 <ThumbnailImage
                   loading="lazy"
                   className="h-full w-full object-cover"
-                  src={c.img}
+                  src={`https://cdn.keycap-archivist.com/keycaps/${c.id}.jpg`}
                   alt={`${maker.name} - ${sculpt.name} - ${c.name}`}
                 />
               </Link>


### PR DESCRIPTION
Once migration will be done on S3, this will be the fallback to get rid of accessing directly to 
google images.