### PR TITLE
Limit wishlist Title to 50 chars

### DIFF
--- a/src/pages/wishlist.js
+++ b/src/pages/wishlist.js
@@ -353,6 +353,7 @@ const Wishlist = () => {
               id="titleText"
               type="text"
               value={wishlist.settings.title.text}
+              maxLength="50"
               onChange={(e) => setSettingWishlist('title', 'text', e)}
               placeholder={wishlist.tradeItems.length ? 'Want' : 'Wishlist'}
             />


### PR DESCRIPTION
A small change to the titleText input to limit the title to 50 characters as going above 50 causes an error seen in the attached screenshot. Instead of handling the title over 50, just limit the length as the extraText input already has this parameter.

![image](https://user-images.githubusercontent.com/13240985/141667634-dad26af7-304d-40df-b4e3-56c31109d0e7.png)
