### PR TITLE
Display commissioned if preset

### DIFF
--- a/src/pages-dynamic/colorway.js
+++ b/src/pages-dynamic/colorway.js
@@ -72,6 +72,14 @@ const Maker = (props) => {
             ) : (
               ''
             )}
+            {colorway.commissioned ? (
+              <div className="mt-2">
+                <FontAwesomeIcon icon={['fa', 'palette']} />
+                <span className="font-bold mx-2">Commissioned</span>
+              </div>
+            ) : (
+              ''
+            )}
           </div>
           <div className="flex flex-row flex-no-wrap flex-shrink-0 mt-1 items-start">
             {!colorway.name && (


### PR DESCRIPTION
This will display a "Commissioned" tag if present removing the need to denote it elsewhere in the name of the colorway