### PR TITLE
ci: use pnpm 9 to match lockfileVersion 9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 9
           run_install: true
       - name: lint
         run: pnpm lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 9
           run_install: true
       - name: lint
         run: pnpm lint

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -22,7 +22,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 9
           run_install: true
       - name: Update database
         env:

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -22,7 +22,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 9
           run_install: true
       - name: Update database
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,6 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 9
           run_install: true
       - name: lint
         run: pnpm lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
         name: Install pnpm
         id: pnpm-install
         with:
-          version: 8
+          version: 9
           run_install: true
       - name: lint
         run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "description": "",
   "version": "0.1.0",
+  "packageManager": "pnpm@9.15.9",
   "dependencies": {
     "@babel/plugin-proposal-decorators": "7.24.1",
     "@fortawesome/fontawesome-svg-core": "6.5.2",


### PR DESCRIPTION
CI pinned pnpm 8, which can't read this repo's lockfileVersion 9.0 lockfile and silently re-resolved all dependencies fresh on every build — pulling in sanitize-html 2.17.6 → ESM-only htmlparser2 12, which has been breaking `gatsby build` with ERR_REQUIRE_ESM since July 13; pinning pnpm 9 makes CI honor the lockfile again. The pnpm version is pinned once via the `packageManager` field in package.json so CI, corepack, and Renovate stay aligned.